### PR TITLE
Simplifying and de-duplicating the Snapshot initialisation logic

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -121,10 +121,10 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     protected void determineSnapshotOffset(SnapshotContext ctx) throws Exception {
         PostgresOffsetContext offset = (PostgresOffsetContext) ctx.offset;
         final long xlogStart = getTransactionStartLsn();
-        final long txId = jdbcConnection.currentTransactionId().longValue();
+        final long txId = jdbcConnection.currentTransactionId();
         LOGGER.info("Read xlogStart at '{}' from transaction '{}'", ReplicationConnection.format(xlogStart), txId);
         if (offset == null) {
-            offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock());
+            offset = PostgresOffsetContext.snapshotInitialOffsetContext(connectorConfig, xlogStart, txId, getClock());
             ctx.offset = offset;
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -261,6 +261,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     @Override
+    public long getDefaultStartingPosition() {
+        return defaultStartingPos;
+    }
+
+    @Override
     public Optional<SlotCreationResult> createReplicationSlot() throws SQLException {
         // note that some of these options are only supported in pg94+, additionally
         // the options are not yet exported by the jdbc api wrapper, therefore, we just do this ourselves

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -83,6 +83,13 @@ public interface ReplicationConnection extends AutoCloseable {
     boolean isConnected() throws SQLException;
 
     /**
+     * The default starting position is either the latest flushed LSN or xlogpos.
+     *
+     * @return the LSN to resume from when no previous LSN is found in Kafka
+     */
+    long getDefaultStartingPosition();
+
+    /**
      * Creates a new {@link Builder} instance which can be used for creating replication connections.
      *
      * @param jdbcConfig a {@link Configuration} instance that contains JDBC settings; may not be null


### PR DESCRIPTION
Removes the code from the PostgresOffsetContext that makes jdbc calls to determine the offset location. Forces the client code to provide this information. 

1. `PostgresSnapshotChangeEventSource` - Requests and initial context to start from the lsn and txId of the snapshot
1. `PostgresStreamingChangeEventSource` - Requests and initial context to start from a `defaultStartPostition` that is supplied by the replication connection